### PR TITLE
tmp: sets odh-dashboard image to maistra-dev version

### DIFF
--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -20,8 +20,8 @@ resources:
 - service.yaml
 images:
 - name: odh-dashboard
-  newName: quay.io/opendatahub/odh-dashboard
-  newTag: v2.5.2
+  newName: quay.io/maistra-dev/odh-dashboard
+  newTag: maistra-dev
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
   newTag: v4.8


### PR DESCRIPTION
Use our own modified image of odh-dashboard built from `maistra/odh-dashboard` in order to avoid injecting oauth-proxy into the notebook pods.