### PR TITLE
chore(owners): adds OSSM-RHODS members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,16 @@
 # Each list is sorted alphabetically, additions should maintain that order
 approvers:
 - anishasthana
+- bartoszmajsak
+- cam-garrison
+- InnocentK
 - lavlas
 - VaishnaviHire
 
 reviewers:
 - anishasthana
+- bartoszmajsak
+- cam-garrison
+- InnocentK
 - lavlas
 - VaishnaviHire


### PR DESCRIPTION
This will allow the OSSM team to review and approve PRs on our own fork of ODH-Manifests. We will likely need to exclude these changes when we merge our fork into ODH-Manifests in the future