### PR TITLE
fix(oauth): corrects signout_path to make logout working

### DIFF
--- a/auth/mesh/proxy/filter-oauth2.yaml
+++ b/auth/mesh/proxy/filter-oauth2.yaml
@@ -65,7 +65,7 @@ spec:
               exact: /callback
           signout_path:
             path:
-              exact: /logout
+              exact: /oauth/sign_out
           credentials:
             client_id: odh
             token_secret:


### PR DESCRIPTION
This change results in redirecting to the login page as it now points to the correct URI for signing out.

Note: when inspecting network tab in e.g. chromium you will notice CORS error. I am investigating it but it does not seem to be a blocker for the OAuth flow to kick in again.

Tested in Chrome and Firefox.

![logout](https://user-images.githubusercontent.com/719616/231174768-99f93653-0292-4434-8ef3-55c0efd36948.gif)

