### PR TITLE
feat: basic support of ModelMesh

### DIFF
--- a/enabling-ossm.md
+++ b/enabling-ossm.md
@@ -118,6 +118,22 @@ spec:
         name: manifests
         path: service-mesh/authorino
    name: authorino
+ - kustomizeConfig:
+      parameters:
+        - name: monitoring-namespace
+          value: opendatahub
+      repoRef:
+        name: manifests
+        path: model-mesh
+   name: model-mesh
+ - kustomizeConfig:
+      parameters:
+        - name: deployment-namespace
+          value: opendatahub
+      repoRef:
+        name: manifests
+        path: modelmesh-monitoring
+   name: modelmesh-monitoring
  repos:
  - name: manifests
    uri: https://github.com/maistra/odh-manifests/tarball/service-mesh-integration

--- a/model-mesh/base/params.env
+++ b/model-mesh/base/params.env
@@ -4,4 +4,4 @@ odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.1
 odh-modelmesh=quay.io/opendatahub/modelmesh:v0.11.0-alpha
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-gpu
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:v0.11.0-alpha
-odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.11.0-alpha
+odh-model-controller=quay.io/edgarhz/odh-model-controller:service-mesh-integration

--- a/model-mesh/odh-model-controller/rbac/role.yaml
+++ b/model-mesh/odh-model-controller/rbac/role.yaml
@@ -113,6 +113,7 @@ rules:
     verbs:
       - get
       - list
+      - update
       - watch
   - apiGroups:
       - serving.kserve.io

--- a/model-mesh/odh-modelmesh-controller/overlays/odh/quickstart.yaml
+++ b/model-mesh/odh-modelmesh-controller/overlays/odh/quickstart.yaml
@@ -41,6 +41,7 @@ spec:
     metadata:
       labels:
         component: model-mesh-etcd
+        sidecar.istio.io/inject: "false"
     spec:
       volumes:
         - name: scripts

--- a/odh-dashboard/overlays/service-mesh/gateway.yaml
+++ b/odh-dashboard/overlays/service-mesh/gateway.yaml
@@ -15,3 +15,9 @@ spec:
       credentialName: odh-dashboard-cert
     hosts:
     - "*"
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"

--- a/service-mesh/control-plane/base/auth-policy.yaml
+++ b/service-mesh/control-plane/base/auth-policy.yaml
@@ -14,4 +14,14 @@ spec:
   - to:
     - operation:
         # hosts: ["odh-dashboard.opendatahub.svc.cluster.local"] # todo: add more?
-        notPaths: ["/auth/*", "/metrics/*"] # todo: see if this is necessary
+        notPaths: # todo: see if this is necessary
+        - "/auth/*"
+        - "/metrics/*"
+        # FIXME: This always bypasses authZ for ModelMesh. It should not if
+        # the model is flagged to be auth-protected.
+        - "/modelmesh/*"
+        - "/vmodel-route/*"
+    when:
+    - key: request.headers[Content-Type]
+      notValues:
+      - "application/grpc*"

--- a/service-mesh/control-plane/base/resource-templates/filter-oauth2.yaml
+++ b/service-mesh/control-plane/base/resource-templates/filter-oauth2.yaml
@@ -79,3 +79,12 @@ spec:
           auth_scopes:
             - user:full
           forward_bearer_token: true 
+          # FIXME: This always bypasses authN for ModelMesh. It should not if
+          # the model is flagged to be auth-protected.
+          pass_through_matcher:
+          - name: ":path"
+            prefix_match: "/modelmesh/"
+          - name: ":path"
+            prefix_match: "/vmodel-route/"
+          - name: content-type
+            prefix_match: application/grpc


### PR DESCRIPTION
On-boarding ModelMesh to the MVP of the Service Mesh integration.

This PR depends on the following ones being merged:
* https://github.com/opendatahub-io/odh-model-controller/pull/50
* https://github.com/maistra/odh-project-controller/pull/17

This would install ModelMesh + its monitoring. Monitoring seems to be required, because the `odh-model-controller` uses a ClusterRole that is created by `modelmesh-monitoring`. It fails if it is not there.

Sidecar injection is, for now, turned off in `etcd` because it has an initContainer which fails to do its job when the Istio sidecar is present.

The resulting installation works at least from a pure ModelMesh perspective; i.e. without involving Istio in an infer request. VirtualServices for ModelMesh routing, although correctly created and associated to Gateways and the Ingress, do not work (trying to do an infer request results in an error). The right configurations still need to be figured out.
