### PR TITLE
chore(init-job): adds annotation to root namespace

### DIFF
--- a/service-mesh/control-plane/base/init-job-rbac/job-cluster-role.yaml
+++ b/service-mesh/control-plane/base/init-job-rbac/job-cluster-role.yaml
@@ -11,6 +11,7 @@ rules:
       - pods/log
       - pods/exec
       - secrets
+      - namespaces
     verbs:
       - create
       - delete

--- a/service-mesh/control-plane/base/init-job.yaml
+++ b/service-mesh/control-plane/base/init-job.yaml
@@ -54,6 +54,9 @@ spec:
                 --from-file=token-secret.yaml=<(envsubst < $TOKEN_FILEPATH) \
                 --from-file=hmac-secret.yaml=<(envsubst < $HMAC_FILEPATH)
 
+            # add annotation to the root namespace (hardcoded pre-plugin)
+            kubectl annotate namespace opendatahub opendatahub.io/service-mesh=true
+
             # wait for app to be ready
             echo "waiting for SMCP to be ready"
             kubectl -n istio-system wait --for=condition=Ready smcp/basic --timeout=180s          


### PR DESCRIPTION
This PR adds the `opendatahub.io/service-mesh: "true"` annotation to the base namespace of the KfDef. However this should likely be handled by the operator plugin in the near future, as I was unable to find how to do so without hardcoding the namespace as opendatahub.
