### PR TITLE
fix: extracts port and raw host

### DIFF
--- a/service-mesh/control-plane/base/init-job.yaml
+++ b/service-mesh/control-plane/base/init-job.yaml
@@ -29,7 +29,9 @@ spec:
             endpoint=$(curl https://kubernetes.default.svc/.well-known/oauth-authorization-server -sS -k)
             export TOKEN_ENDPOINT=$(echo $endpoint | jq .token_endpoint)
             export AUTH_ENDPOINT=$(echo $endpoint | jq .authorization_endpoint)
-            export OAUTH_ROUTE=$(echo $endpoint | jq .issuer | sed 's/"//g; s/https:\/\///g') # remove quotes and https
+            issuer=$(echo $endpoint | jq -r '.issuer')
+            export OAUTH_PORT=$(echo $issuer | sed -n 's/.*:\([0-9]\+\)$/\1/p')
+            export OAUTH_ROUTE=$(echo $issuer | sed 's/^https\?:\/\/\([^:\/]*\).*$/\1/')
             export TOKEN_FILEPATH="/etc/cluster-resources/token-secret.yaml"
             export HMAC_FILEPATH="/etc/cluster-resources/hmac-secret.yaml"
 

--- a/service-mesh/control-plane/base/resource-templates/filter-oauth2.yaml
+++ b/service-mesh/control-plane/base/resource-templates/filter-oauth2.yaml
@@ -37,7 +37,7 @@ spec:
                 address:
                   socket_address:
                     address: $OAUTH_ROUTE
-                    port_value: 443
+                    port_value: $OAUTH_PORT
   - applyTo: HTTP_FILTER
     match:
       context: GATEWAY


### PR DESCRIPTION
As before it was simply removing the protocol and leaving the port as part of SNI for example. That lead to filters not being configured properly and thus failing.