### PR TITLE
feat: migrate existing DS project namespaces to enable SM 

### DIFF
--- a/service-mesh/control-plane/base/init-job.yaml
+++ b/service-mesh/control-plane/base/init-job.yaml
@@ -74,10 +74,10 @@ spec:
                 
             # migrate pre-existing data science project namespaces to enable ossm
             # Get the namespaces with the label opendatahub.io/dashboard=true
-            ds_projects=$(oc get namespaces -l opendatahub.io/dashboard=true --no-headers -o custom-columns=NAME:.metadata.name)
+            ds_projects=$(kubectl get namespaces -l opendatahub.io/dashboard=true --no-headers -o custom-columns=NAME:.metadata.name)
             
             # Use xargs to run oc annotate for each DS project namespace found
-            echo $ds_projects | xargs -I {} oc annotate namespace {} opendatahub.io/service-mesh=true --overwrite
+            echo $ds_projects | xargs -I {} kubectl annotate namespace {} opendatahub.io/service-mesh=true --overwrite
             
             # wait for app to be ready
             echo "waiting for SMCP to be ready"

--- a/service-mesh/control-plane/base/init-job.yaml
+++ b/service-mesh/control-plane/base/init-job.yaml
@@ -71,7 +71,14 @@ spec:
 
             # add annotation to the root namespace (hardcoded pre-plugin)
             kubectl annotate namespace ${ODH_NAMESPACE} opendatahub.io/service-mesh=true
-
+                
+            # migrate pre-existing data science project namespaces to enable ossm
+            # Get the namespaces with the label opendatahub.io/dashboard=true
+            ds_projects=$(oc get namespaces -l opendatahub.io/dashboard=true --no-headers -o custom-columns=NAME:.metadata.name)
+            
+            # Use xargs to run oc annotate for each DS project namespace found
+            echo $ds_projects | xargs -I {} oc annotate namespace {} opendatahub.io/service-mesh=true --overwrite
+            
             # wait for app to be ready
             echo "waiting for SMCP to be ready"
             kubectl -n ${ISTIO_NAMESPACE} wait --for=condition=Ready smcp/basic --timeout=180s          


### PR DESCRIPTION
This PR updates the initialization job to include all data science projects that were created through the dashboard and annotates them with service-mesh=true. This is an important step in the migration process, enabling previously created data science projects to be incorporated into the service mesh, and facilitating the odh project controller to detect these namespaces once the migration from a non-mesh to a mesh enabled deployment has been completed.

Tested on CRC by: 
- creating a KfDef without SM resources and overlays
- Creating a data science project without mesh - creating a notebook inside the ds proj
- applying a KfDef with sm resources and overlays
- ensuring that the NS is annotated by init-job, and then that the notebook is linked to successfully by dashboard