### PR TITLE
chore: specifies host in ODH dashboard gateway and virtualservice

### DIFF
--- a/odh-dashboard/overlays/service-mesh/kustomization.yaml
+++ b/odh-dashboard/overlays/service-mesh/kustomization.yaml
@@ -6,8 +6,6 @@ bases:
 
 resources:
 - dashboard-config.yaml
-- gateway.yaml
-- virtual-service.yaml
 
 patchesStrategicMerge:
 # when using bases:

--- a/service-mesh/templates/control-plane/base/gateway.tmpl
+++ b/service-mesh/templates/control-plane/base/gateway.tmpl
@@ -13,7 +13,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: odh-dashboard-cert
+      credentialName: {{ .Mesh.Certificate.Name }}
     hosts:
     - "opendatahub.{{ .Domain }}"
   - port:

--- a/service-mesh/templates/control-plane/base/gateway.tmpl
+++ b/service-mesh/templates/control-plane/base/gateway.tmpl
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: odh-gateway
+  namespace: {{ .AppNamespace }}
 spec:
   selector:
     istio: ingressgateway
@@ -12,6 +13,12 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: opendatahub-dashboard-cert
+      credentialName: odh-dashboard-cert
     hosts:
-    - "*"
+    - "opendatahub.{{ .Domain }}"
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "opendatahub.{{ .Domain }}"

--- a/service-mesh/templates/control-plane/base/virtual-service.tmpl
+++ b/service-mesh/templates/control-plane/base/virtual-service.tmpl
@@ -2,11 +2,12 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: odh-dashboard
+  namespace: {{ .AppNamespace }}
 spec:
   gateways:
   - odh-gateway
   hosts:
-  - "*"
+  - "opendatahub.{{ .Domain }}"
   http:
   - route:
     - destination:


### PR DESCRIPTION
This PR changes our template based manifests to create the ODH gateway and VS so that they specify their hosts. See PR #27  