### PR TITLE
fix: rewrites url on notebook logout

### DIFF
--- a/service-mesh/templates/control-plane/base/virtual-service.tmpl
+++ b/service-mesh/templates/control-plane/base/virtual-service.tmpl
@@ -12,6 +12,11 @@ spec:
   - match:
     - uri:
         regex: "^/notebook/.*/.*/logout"
+    route:
+    - destination:
+        host: odh-dashboard
+        port:
+          number: 80
     rewrite:
       uri: "/oauth/sign_out"
   - route:

--- a/service-mesh/templates/control-plane/base/virtual-service.tmpl
+++ b/service-mesh/templates/control-plane/base/virtual-service.tmpl
@@ -11,6 +11,7 @@ spec:
   http:
   - match:
     - uri:
+        # match host.com/notebook/ns/username/logout 
         regex: "^/notebook/.*/.*/logout"
     route:
     - destination:

--- a/service-mesh/templates/control-plane/base/virtual-service.tmpl
+++ b/service-mesh/templates/control-plane/base/virtual-service.tmpl
@@ -9,6 +9,11 @@ spec:
   hosts:
   - "opendatahub.{{ .Domain }}"
   http:
+  - match:
+    - uri:
+        regex: "^/notebook/.*/.*/logout"
+    rewrite:
+      uri: "/oauth/sign_out"
   - route:
     - destination:
         host: odh-dashboard


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-4385

Adds a rewrite rule to the dashboard VirtualService to rewrite a notebook logout request to our pre-existing logout destination. This fixes hitting the logout button from inside of notebooks started from data science project or the jupyter tile. 

Tested on CRC, creating a notebook and logging out successfully logs out.