### PR TITLE
fix: rewrites url on notebook logout

### DIFF
--- a/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
+++ b/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
@@ -8,6 +8,16 @@ spec:
   hosts:
   - "opendatahub.$DOMAIN"
   http:
+  - match:
+    - uri:
+        regex: "^/notebook/.*/.*/logout"
+    route:
+    - destination:
+        host: odh-dashboard
+        port:
+          number: 80
+    rewrite:
+      uri: "/oauth/sign_out"
   - route:
     - destination:
         host: odh-dashboard

--- a/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
+++ b/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
@@ -10,6 +10,7 @@ spec:
   http:
   - match:
     - uri:
+        # match host.com/notebook/ns/username/logout 
         regex: "^/notebook/.*/.*/logout"
     route:
     - destination:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-4385

Adds a rewrite rule to the dashboard VirtualService to rewrite a notebook logout request to our pre-existing logout destination. This fixes hitting the logout button from inside of notebooks started from data science project or the jupyter tile.

Not tested this PR, but tested #29 