### PR TITLE
fix: remove ODHDashboardConfig patch

### DIFF
--- a/odh-dashboard/overlays/service-mesh/dashboard-config.yaml
+++ b/odh-dashboard/overlays/service-mesh/dashboard-config.yaml
@@ -1,7 +1,0 @@
-apiVersion: opendatahub.io/v1alpha
-kind: OdhDashboardConfig
-metadata:
-  name: odh-dashboard-config
-spec:
-  dashboardConfig:
-    disableServiceMesh: false

--- a/odh-dashboard/overlays/service-mesh/kustomization.yaml
+++ b/odh-dashboard/overlays/service-mesh/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 bases:
 - ../../base
 
-resources:
-- dashboard-config.yaml
-
 patchesStrategicMerge:
 # when using bases:
 # - ../../base


### PR DESCRIPTION
Now that the operator plugin code handles patching the dashboard config more gracefully (the previous method did not work as intended), we can remove the dashboard config patch from manifests. 